### PR TITLE
cmake fix for PGI 16.10 not recognizing -std=c99 flag

### DIFF
--- a/src/libint_compiler/CMakeLists.txt
+++ b/src/libint_compiler/CMakeLists.txt
@@ -15,7 +15,14 @@ set(COMPILER_SRC build_libint.c
 add_executable(libint_compiler ${COMPILER_SRC})
 find_package(M REQUIRED)
 target_link_libraries(libint_compiler ${LIBM_LIBRARIES})
-set_target_properties(libint_compiler PROPERTIES COMPILE_FLAGS "-std=c99")
+
+
+
+if ("${CMAKE_C_COMPILER_ID}" STREQUAL "PGI")
+  set_target_properties(libint_compiler PROPERTIES COMPILE_FLAGS "-c99")
+else()
+  set_target_properties(libint_compiler PROPERTIES COMPILE_FLAGS "-std=c99")
+endif()
 
 math(EXPR LIBINT_NEW_AM ${MAX_AM_ERI}*2)
 target_compile_definitions(libint_compiler


### PR DESCRIPTION
## Description
PGI C-compiler (V 16.10 tested) does not recognize the `-std=c99` flag like many other compilers. A CMake if-clause was inserted to catch that and change the flag to `-c99
`
## Status
- [x] ready

---
hope I am doing this pull request thing correctly.